### PR TITLE
Implement Scrapy listing spider and data model

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,18 @@
 This repository contains the code for a modular scraper–filter–AI pipeline that identifies good deals from online listings.
 
 See [TASK.md](TASK.md) for the detailed project plan and [ENGINEERING_GUIDELINES.md](ENGINEERING_GUIDELINES.md) for development standards.
+
+## Web Scraper
+
+The first deliverable is a Scrapy-based spider that extracts structured `Listing`
+objects from listing pages.
+
+Run the spider and save results to JSON:
+
+```bash
+scrapy runspider src/dba_agent/services/scraper.py -O listings.json
+```
+
+The output file contains newline-delimited JSON representations of each
+`Listing` with fields for title, price, description, images, location and
+timestamp.

--- a/src/dba_agent/models/__init__.py
+++ b/src/dba_agent/models/__init__.py
@@ -1,1 +1,5 @@
-"""${d^} module for the DBA deal-finding system."""
+"""Data models for the DBA deal-finding system."""
+
+from .listing import Listing
+
+__all__ = ["Listing"]

--- a/src/dba_agent/models/listing.py
+++ b/src/dba_agent/models/listing.py
@@ -1,0 +1,19 @@
+"""Data models for scraped listings."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class Listing(BaseModel):
+    """Represents a single scraped listing from an external site."""
+
+    title: str
+    price: float
+    description: Optional[str] = None
+    image_urls: List[HttpUrl] = Field(default_factory=list)
+    location: Optional[str] = None
+    timestamp: datetime

--- a/src/dba_agent/services/__init__.py
+++ b/src/dba_agent/services/__init__.py
@@ -1,1 +1,5 @@
-"""${d^} module for the DBA deal-finding system."""
+"""Service layer for the DBA deal-finding system."""
+
+from .scraper import ListingSpider, fetch_dynamic
+
+__all__ = ["ListingSpider", "fetch_dynamic"]

--- a/src/dba_agent/services/scraper.py
+++ b/src/dba_agent/services/scraper.py
@@ -1,0 +1,67 @@
+"""Web scraping utilities built on Scrapy."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, Iterator, Optional
+
+import scrapy
+from scrapy import Request
+from scrapy.http import Response
+
+from dba_agent.models import Listing
+
+
+class ListingSpider(scrapy.Spider):  # type: ignore[misc]
+    """Basic spider that extracts ``Listing`` objects from listing cards."""
+
+    name = "listings"
+    custom_settings = {
+        "DOWNLOAD_DELAY": 0.5,
+        "AUTOTHROTTLE_ENABLED": True,
+        "RETRY_TIMES": 3,
+    }
+
+    def __init__(
+        self, start_urls: Optional[Iterable[str]] = None, **kwargs: object
+    ) -> None:
+        super().__init__(**kwargs)
+        self.start_urls = list(start_urls or [])
+
+    def parse(
+        self, response: Response, **kwargs: object
+    ) -> Iterator[Listing | Request]:
+        """Parse listing cards on the page and follow pagination links."""
+
+        for card in response.css("div.listing"):
+            yield Listing(
+                title=card.css("h2::text").get(default="").strip(),
+                price=float(card.css("span.price::text").re_first(r"[\d.]+") or 0.0),
+                description=card.css("p.description::text").get(),
+                image_urls=card.css("img::attr(src)").getall(),
+                location=card.css("span.location::text").get(),
+                timestamp=datetime.now(timezone.utc),
+            )
+
+        next_page = response.css("a.next::attr(href)").get()
+        if next_page:
+            yield response.follow(next_page, callback=self.parse)
+
+
+def fetch_dynamic(url: str, wait_time: float = 0.0) -> str:
+    """Fetch page HTML using Selenium for sites requiring JS rendering."""
+
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    import time
+
+    options = Options()
+    options.add_argument("--headless")
+    driver = webdriver.Chrome(options=options)
+    try:
+        driver.get(url)
+        if wait_time:
+            time.sleep(wait_time)
+        return str(driver.page_source)
+    finally:
+        driver.quit()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from scrapy.http import HtmlResponse
+
+from dba_agent.services import ListingSpider
+from dba_agent.models import Listing
+
+
+HTML = """
+<html>
+  <body>
+    <div class="listing">
+      <h2>Widget</h2>
+      <span class="price">$9.99</span>
+      <p class="description">Great widget</p>
+      <img src="http://example.com/img1.jpg" />
+      <span class="location">Springfield</span>
+    </div>
+    <a class="next" href="/page2.html">Next</a>
+  </body>
+</html>
+"""
+
+
+def test_listing_spider_parses_listing() -> None:
+    spider = ListingSpider(start_urls=["http://example.com"])
+    response = HtmlResponse(url="http://example.com", body=HTML, encoding="utf-8")
+    results = list(spider.parse(response))
+
+    assert results
+    listing = results[0]
+    assert isinstance(listing, Listing)
+    assert listing.title == "Widget"
+    assert listing.price == 9.99
+    assert [str(url) for url in listing.image_urls] == ["http://example.com/img1.jpg"]
+    assert listing.location == "Springfield"


### PR DESCRIPTION
## Summary
- add typed `Listing` model for scraped data
- implement `ListingSpider` and `fetch_dynamic` helper
- cover spider parsing with unit tests
- document how to run the spider in README

## Testing
- `pre-commit run --files README.md src/dba_agent/models/__init__.py src/dba_agent/models/listing.py src/dba_agent/services/__init__.py src/dba_agent/services/scraper.py tests/test_scraper.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1d093ffb483258c9b2975dbe1f1c8