### PR TITLE
Download listing images instead of URLs

### DIFF
--- a/src/dba_agent/models/listing.py
+++ b/src/dba_agent/models/listing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field
 
 
 class Listing(BaseModel):
@@ -14,6 +14,6 @@ class Listing(BaseModel):
     title: str
     price: float
     description: Optional[str] = None
-    image_urls: List[HttpUrl] = Field(default_factory=list)
+    images: List[bytes] = Field(default_factory=list)
     location: Optional[str] = None
     timestamp: datetime


### PR DESCRIPTION
## Summary
- Store listing images as raw bytes instead of URLs
- Spider now downloads images with a helper
- Adjust tests for new image handling

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dc8e97c08325a956146da0de8329